### PR TITLE
Fix RSS item pubDate parsing

### DIFF
--- a/abcjustinrss.go
+++ b/abcjustinrss.go
@@ -128,9 +128,21 @@ func FetchAndParseNewsToRSS() (RSS, error) {
 			continue
 		}
 
-		// Extract relative time (e.g., "15 minutes ago")
-		relativeTime := strings.TrimSpace(s.Find("time").Text())
-		pubDate := DeducePublicationDate(relativeTime)
+		// Extract pubDate
+		var pubDate string
+		dateTime, exists := s.Find("time[datetime]").Attr("datetime")
+		if exists {
+			t, err := time.Parse(time.RFC3339, dateTime)
+			if err == nil {
+				pubDate = t.Format(time.RFC1123)
+			}
+		}
+
+		if pubDate == "" {
+			// Fallback: Extract relative time (e.g., "15 minutes ago")
+			relativeTime := strings.TrimSpace(s.Find("time").Text())
+			pubDate = DeducePublicationDate(relativeTime)
+		}
 
 		linkUrl, err := baseUrl.Parse(link)
 		if err != nil {

--- a/abcjustinrss_test.go
+++ b/abcjustinrss_test.go
@@ -1,0 +1,75 @@
+package abcjustinrss
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/PuerkitoBio/goquery"
+)
+
+func TestExtractPubDate(t *testing.T) {
+	tests := []struct {
+		name     string
+		html     string
+		expected string // We'll just check if it parses correctly and produces expected RFC1123
+	}{
+		{
+			name: "With datetime attribute",
+			html: `<article><h3><a href="/news/2026/07/07/test">Test</a></h3>
+	<div data-component="Typography">Desc</div>
+	<a data-component="Link" href="/news/2026/07/07/test">Link</a>
+	<time class="ScreenReaderOnly_srOnly__bnJwm" data-component="ScreenReaderTimestamp" datetime="2026-07-07T04:34:03.000Z">Tue 7 Jul 2026 at 2:34pm</time>
+	</article>`,
+			expected: "Tue, 07 Jul 2026 04:34:03 UTC",
+		},
+		{
+			name: "Without datetime attribute fallback to relative time",
+			html: `<article><h3><a href="/news/2026/07/07/test">Test</a></h3>
+	<div data-component="Typography">Desc</div>
+	<a data-component="Link" href="/news/2026/07/07/test">Link</a>
+	<time>15 minutes ago</time>
+	</article>`,
+			// Expected will vary because time.Now() is used in DeducePublicationDate, so we just check it's not empty and parsable
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc, err := goquery.NewDocumentFromReader(strings.NewReader(tt.html))
+			if err != nil {
+				t.Fatalf("Failed to parse HTML: %v", err)
+			}
+
+			s := doc.Find("article").First()
+
+			var pubDate string
+			dateTime, exists := s.Find("time[datetime]").Attr("datetime")
+			if exists {
+				parsedTime, err := time.Parse(time.RFC3339, dateTime)
+				if err == nil {
+					pubDate = parsedTime.Format(time.RFC1123)
+				}
+			}
+
+			if pubDate == "" {
+				relativeTime := strings.TrimSpace(s.Find("time").Text())
+				pubDate = DeducePublicationDate(relativeTime)
+			}
+
+			if pubDate == "" {
+				t.Errorf("pubDate is empty")
+			}
+
+			if tt.expected != "" && pubDate != tt.expected {
+				t.Errorf("expected pubDate %q, got %q", tt.expected, pubDate)
+			}
+
+			_, err = time.Parse(time.RFC1123, pubDate)
+			if err != nil {
+				t.Errorf("pubDate %q does not match RFC1123 format: %v", pubDate, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Extract exact publication dates using the machine-readable `datetime` attribute from `<time>` elements when scraping ABC News, ensuring RSS items have stable and correct publication dates instead of relying purely on relative time scraping. Falls back to previous behavior if the `datetime` attribute is not present.

---
*PR created automatically by Jules for task [10353816865543402961](https://jules.google.com/task/10353816865543402961) started by @arran4*