### PR TITLE
Update Pages deployment cron schedule to run hourly

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,9 +1,9 @@
 name: Deploy to GitHub Pages
 
 on:
-  # Daily schedule (just after the usual release date - 21:00 UTC is early morning in Australia)
+  # Hourly schedule
   schedule:
-    - cron: '0 21 * * *'
+    - cron: '0 * * * *'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
Updated the cron expression in `.github/workflows/pages.yml` to trigger the GitHub Pages deployment once an hour instead of once a day. Changed the comment to match the new behavior.

---
*PR created automatically by Jules for task [17173490388102264835](https://jules.google.com/task/17173490388102264835) started by @arran4*